### PR TITLE
Add NYC gov jobs advanced search UI with dynamic filter builder

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,230 @@
+const filtersList = document.getElementById("filters-list");
+const addFilterButton = document.getElementById("add-filter");
+const resetFiltersButton = document.getElementById("reset-filters");
+const queryPreview = document.getElementById("query-preview");
+const resultsContainer = document.getElementById("results");
+const resultsCount = document.getElementById("results-count");
+
+const operatorOptions = {
+  keyword: ["contains", "does not contain"],
+  agency: ["is", "is not", "contains"],
+  category: ["is", "is not"],
+  salary: ["between", ">=", "<="] ,
+  date: ["after", "before", "on"],
+  location: ["is", "is not", "contains"],
+  type: ["is", "is not"],
+  level: ["is", "is not"],
+  schedule: ["is", "is not"],
+};
+
+const sampleJobs = [
+  {
+    title: "Program Manager, Community Affairs",
+    agency: "Mayor's Office",
+    location: "Manhattan",
+    level: "Manager",
+    type: "Full-time",
+    salary: "$82,000 - $95,000",
+  },
+  {
+    title: "Data Analyst",
+    agency: "Department of Health",
+    location: "Queens",
+    level: "Mid-level",
+    type: "Full-time",
+    salary: "$76,500 - $88,000",
+  },
+  {
+    title: "Civil Engineer",
+    agency: "Department of Transportation",
+    location: "Brooklyn",
+    level: "Senior",
+    type: "Full-time",
+    salary: "$98,000 - $120,000",
+  },
+];
+
+const createFilterId = (() => {
+  let id = 0;
+  return () => {
+    id += 1;
+    return `filter-${id}`;
+  };
+})();
+
+const buildOperatorOptions = (operatorSelect, field) => {
+  operatorSelect.innerHTML = "";
+  operatorOptions[field].forEach((option) => {
+    const opt = document.createElement("option");
+    opt.value = option;
+    opt.textContent = option;
+    operatorSelect.appendChild(opt);
+  });
+};
+
+const updateInputType = (filterElement, field) => {
+  const input = filterElement.querySelector(".filter__input");
+  const wrapper = filterElement.querySelector(".filter__value");
+
+  input.type = "text";
+  input.placeholder = "Add a value";
+
+  if (field === "salary") {
+    input.type = "text";
+    input.placeholder = "e.g. 70000 - 90000";
+  }
+
+  if (field === "date") {
+    input.type = "date";
+  }
+
+  wrapper.querySelector("span")?.remove();
+};
+
+const addFilter = (defaults = {}) => {
+  const template = document.getElementById("filter-template");
+  const filterElement = template.content.firstElementChild.cloneNode(true);
+  const filterId = createFilterId();
+
+  filterElement.dataset.filterId = filterId;
+
+  const fieldSelect = filterElement.querySelector(".filter__field");
+  const operatorSelect = filterElement.querySelector(".filter__operator");
+  const input = filterElement.querySelector(".filter__input");
+  const removeButton = filterElement.querySelector(".filter__remove");
+
+  fieldSelect.value = defaults.field || "keyword";
+  buildOperatorOptions(operatorSelect, fieldSelect.value);
+  operatorSelect.value = defaults.operator || operatorSelect.options[0].value;
+  input.value = defaults.value || "";
+  updateInputType(filterElement, fieldSelect.value);
+
+  fieldSelect.addEventListener("change", () => {
+    buildOperatorOptions(operatorSelect, fieldSelect.value);
+    updateInputType(filterElement, fieldSelect.value);
+    updatePreview();
+  });
+
+  operatorSelect.addEventListener("change", updatePreview);
+  input.addEventListener("input", updatePreview);
+
+  removeButton.addEventListener("click", () => {
+    filterElement.remove();
+    updatePreview();
+  });
+
+  filtersList.appendChild(filterElement);
+};
+
+const getFilters = () => {
+  return Array.from(filtersList.children).map((filter) => {
+    return {
+      field: filter.querySelector(".filter__field").value,
+      operator: filter.querySelector(".filter__operator").value,
+      value: filter.querySelector(".filter__input").value.trim(),
+    };
+  });
+};
+
+const updatePreview = () => {
+  const filters = getFilters();
+  if (!filters.length) {
+    queryPreview.textContent = "Add filters to generate a query preview.";
+    resultsContainer.innerHTML = "";
+    resultsCount.textContent = "0 matches";
+    return;
+  }
+
+  const filterDescriptions = filters.map((filter) => {
+    const value = filter.value || "(any value)";
+    return `${filter.field} ${filter.operator} ${value}`;
+  });
+
+  queryPreview.textContent = filterDescriptions.join(" AND ");
+  renderResults(filters);
+};
+
+const getFieldValue = (job, field) => {
+  if (field === "keyword") {
+    return `${job.title} ${job.agency} ${job.location}`;
+  }
+
+  if (field === "salary") {
+    return job.salary;
+  }
+
+  return job[field] || "";
+};
+
+const renderResults = (filters) => {
+  resultsContainer.innerHTML = "";
+  const matches = sampleJobs.filter((job) => {
+    return filters.every((filter) => {
+      if (!filter.value) {
+        return true;
+      }
+
+      const fieldValue = getFieldValue(job, filter.field);
+      const normalizedField = fieldValue.toLowerCase();
+      const normalizedValue = filter.value.toLowerCase();
+
+      if (filter.operator === "contains") {
+        return normalizedField.includes(normalizedValue);
+      }
+
+      if (filter.operator === "does not contain") {
+        return !normalizedField.includes(normalizedValue);
+      }
+
+      if (filter.operator === "is") {
+        return normalizedField === normalizedValue;
+      }
+
+      if (filter.operator === "is not") {
+        return normalizedField !== normalizedValue;
+      }
+
+      return true;
+    });
+  });
+
+  matches.forEach((job) => {
+    const card = document.createElement("article");
+    card.className = "result-card";
+    card.innerHTML = `
+      <h3>${job.title}</h3>
+      <div class="result-meta">
+        <span>${job.agency}</span>
+        <span>${job.location}</span>
+        <span>${job.level}</span>
+        <span>${job.type}</span>
+      </div>
+      <strong>${job.salary}</strong>
+    `;
+    resultsContainer.appendChild(card);
+  });
+
+  resultsCount.textContent = `${matches.length} match${matches.length === 1 ? "" : "es"}`;
+};
+
+addFilter({ field: "keyword", operator: "contains", value: "" });
+addFilter({ field: "agency", operator: "is", value: "" });
+
+addFilterButton.addEventListener("click", () => {
+  addFilter();
+  updatePreview();
+});
+
+resetFiltersButton.addEventListener("click", () => {
+  filtersList.innerHTML = "";
+  addFilter({ field: "keyword", operator: "contains", value: "" });
+  updatePreview();
+});
+
+const filtersForm = document.getElementById("filters-form");
+filtersForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  updatePreview();
+});
+
+updatePreview();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NYC Gov Jobs Advanced Search</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="hero__content">
+        <p class="hero__eyebrow">NYC Careers Explorer</p>
+        <h1>Search NYC government jobs with flexible filters.</h1>
+        <p>
+          Build complex job searches with as many filters as you need, then save and
+          reuse them anytime.
+        </p>
+      </div>
+    </header>
+
+    <main class="container">
+      <section class="panel">
+        <div class="panel__header">
+          <div>
+            <h2>Advanced filters</h2>
+            <p>Add, reorder, and refine filters to focus on the roles you want.</p>
+          </div>
+          <button class="button button--ghost" id="reset-filters">Reset</button>
+        </div>
+
+        <form id="filters-form">
+          <div class="filters" id="filters-list"></div>
+          <div class="actions">
+            <button type="button" class="button button--secondary" id="add-filter">
+              + Add filter
+            </button>
+            <button type="submit" class="button">Search jobs</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="panel panel--light">
+        <div class="panel__header">
+          <div>
+            <h2>Search preview</h2>
+            <p>See the combined search query you are building.</p>
+          </div>
+          <button class="button button--ghost" id="save-search">Save search</button>
+        </div>
+        <div class="preview" id="query-preview">
+          Add filters to generate a query preview.
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel__header">
+          <div>
+            <h2>Matching jobs</h2>
+            <p>Preview results based on your filters.</p>
+          </div>
+          <span class="badge" id="results-count">0 matches</span>
+        </div>
+        <div class="results" id="results"></div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>
+        NYC Gov Jobs Explorer &middot; Build as many filters as you like, then share
+        the search with your team.
+      </p>
+    </footer>
+
+    <template id="filter-template">
+      <div class="filter" data-filter-id="">
+        <div class="filter__header">
+          <span class="filter__title">Filter</span>
+          <button type="button" class="button button--ghost filter__remove">Remove</button>
+        </div>
+        <div class="filter__body">
+          <label>
+            Field
+            <select class="filter__field">
+              <option value="keyword">Keyword</option>
+              <option value="agency">Agency</option>
+              <option value="category">Job Category</option>
+              <option value="salary">Salary Range</option>
+              <option value="date">Posting Date</option>
+              <option value="location">Work Location</option>
+              <option value="type">Employment Type</option>
+              <option value="level">Career Level</option>
+              <option value="schedule">Work Schedule</option>
+            </select>
+          </label>
+          <label>
+            Operator
+            <select class="filter__operator"></select>
+          </label>
+          <label class="filter__value">
+            Value
+            <input class="filter__input" type="text" placeholder="Add a value" />
+          </label>
+        </div>
+      </div>
+    </template>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,236 @@
+:root {
+  color-scheme: light;
+  --bg: #f5f7fb;
+  --panel: #ffffff;
+  --panel-muted: #f0f4ff;
+  --text: #0e1b2c;
+  --subtle: #4b5b70;
+  --primary: #1244ff;
+  --primary-dark: #0f32b6;
+  --accent: #f7b733;
+  --border: #d9e1f2;
+  --shadow: 0 16px 40px rgba(15, 30, 63, 0.08);
+  font-family: "Inter", "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.hero {
+  background: linear-gradient(120deg, #0f1f5f 0%, #1237b0 40%, #2f6df6 100%);
+  color: #fff;
+  padding: 72px 20px 64px;
+}
+
+.hero__content {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.hero__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+  margin: 0 0 16px;
+  opacity: 0.8;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 5vw, 3.4rem);
+  margin: 0 0 16px;
+}
+
+.hero p {
+  font-size: 1.1rem;
+  max-width: 620px;
+}
+
+.container {
+  max-width: 1100px;
+  margin: -48px auto 60px;
+  padding: 0 20px 40px;
+  display: grid;
+  gap: 24px;
+}
+
+.panel {
+  background: var(--panel);
+  border-radius: 20px;
+  padding: 24px;
+  box-shadow: var(--shadow);
+}
+
+.panel--light {
+  background: var(--panel-muted);
+}
+
+.panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.panel__header h2 {
+  margin: 0 0 6px;
+}
+
+.panel__header p {
+  margin: 0;
+  color: var(--subtle);
+}
+
+.filters {
+  display: grid;
+  gap: 16px;
+}
+
+.filter {
+  border: 1px solid var(--border);
+  padding: 16px;
+  border-radius: 16px;
+  background: #fff;
+}
+
+.filter__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.filter__title {
+  font-weight: 600;
+}
+
+.filter__body {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  gap: 6px;
+  color: var(--subtle);
+}
+
+input,
+select {
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  padding: 10px 12px;
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+.actions {
+  margin-top: 16px;
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.button {
+  border: none;
+  background: var(--primary);
+  color: #fff;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.button:hover {
+  background: var(--primary-dark);
+}
+
+.button--secondary {
+  background: #e5ecff;
+  color: var(--primary-dark);
+}
+
+.button--secondary:hover {
+  background: #d3ddff;
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--primary-dark);
+}
+
+.button--ghost:hover {
+  background: rgba(18, 68, 255, 0.1);
+}
+
+.preview {
+  background: rgba(255, 255, 255, 0.8);
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px dashed var(--border);
+  color: var(--subtle);
+  min-height: 68px;
+}
+
+.results {
+  display: grid;
+  gap: 12px;
+}
+
+.result-card {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 16px;
+  background: #fff;
+  display: grid;
+  gap: 8px;
+}
+
+.result-card h3 {
+  margin: 0;
+}
+
+.result-meta {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  color: var(--subtle);
+  font-size: 0.9rem;
+}
+
+.badge {
+  background: #e7f0ff;
+  color: var(--primary-dark);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.footer {
+  text-align: center;
+  color: var(--subtle);
+  padding: 24px 16px 40px;
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding: 56px 16px 48px;
+  }
+
+  .container {
+    margin-top: -32px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a simple, extendable UI to build complex NYC government job searches using arbitrarily many filters.  
- Offer an immediate preview of the combined query and a live results panel to iterate on filter logic.  
- Make it easy to add new filter fields and operators in the future by centralizing operator lists and field value mapping.

### Description
- Added a static UI in `index.html` that includes panels for advanced filters, a query preview, and a matching results list, plus a `template` for dynamic filters.  
- Implemented styles in `styles.css` for the hero, panels, filters, buttons, preview, and result cards to provide a polished layout.  
- Implemented dynamic filter management and result rendering in `app.js`, including operator option lists, filter add/remove handlers, `getFilters()` and `updatePreview()` logic, and sample job data.  
- Introduced `getFieldValue(job, field)` to map compound fields (e.g., `keyword`) and special handling for `salary`, and updated `renderResults()` to use this mapping for matching logic.

### Testing
- Launched a local web server with `python -m http.server 8000` and verified the page loaded successfully.  
- Ran a Playwright script that navigated to `http://127.0.0.1:8000`, captured a full-page screenshot (`artifacts/nyc-jobs-filters.png`), and completed without error.  
- No unit or CI tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983b42a43c8832084b972b15d0bd236)